### PR TITLE
Fix link function to use laboratory URL

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -461,5 +461,5 @@
   localization.at(text.lang).lab_prefix + " "
   laboratories.at(name).name + linebreak()
   // laboratories.at(name).company + linebreak()
-  link("", laboratories.at(name).url)
+  link(laboratories.at(name).url)
 }


### PR DESCRIPTION
Typst's [Link](https://typst.app/docs/reference/model/link/) element requires the first parameter to be a non-empty URL.

> Error: URL must not be empty